### PR TITLE
Added getGroupPassphraseInfo() to fetch passphrase

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -228,7 +228,7 @@ After `createGroup()` method is exectuted, we can call getGroupPassPhraseInfo() 
 createGroup()
       .then(() => {
         setTimeout(() => {
-          getGroupPassphraseInfo().then(_ => console.log(_));
+          getGroupPassphraseInfo().then(passphrase => console.log(passphrase));
         }, 3000);
       })
       .catch(err => console.error("Something gone wrong. Details: ", err));

--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,7 @@ compile project(':react-native-wifi-p2p')
 * [sendMessage(message)]($sendmessagemessage)
 * [receiveMessage()]()
 * [getConnectionInfo()]() `temporary`
+* [getGroupPassphraseInfo()]() `temporary` 
 * [getGroupInfo()]() `future`
 
 ### CONSTANTS
@@ -217,6 +218,20 @@ Before exit of application you need to call this method, if earlier you created 
 removeGroup()
     .then(() => console.log('Currently you don\'t belong to group!'))
     .catch(err => console.error('Something gone wrong. Details: ', err));
+```
+
+### getGroupPassphraseInfo()
+After `createGroup()` method is exectuted, we can call getGroupPassPhraseInfo() to get passphrase required to connect to WiFI Direct group. Only catch is, not able to chain just immediately after createGroup. Instead, we wait for 3 seconds,
+
+
+```javascript
+createGroup()
+      .then(() => {
+        setTimeout(() => {
+          getGroupPassphraseInfo().then(_ => console.log(_));
+        }, 3000);
+      })
+      .catch(err => console.error("Something gone wrong. Details: ", err));
 ```
 
 ### sendFile(pathToFIle)

--- a/android/src/main/java/io/wifi/p2p/WiFiP2PManagerModule.java
+++ b/android/src/main/java/io/wifi/p2p/WiFiP2PManagerModule.java
@@ -64,6 +64,25 @@ public class WiFiP2PManagerModule extends ReactContextBaseJavaModule implements 
         });
     }
 
+   @ReactMethod
+    public void getGroupPassphraseInfo(final Promise promise) {
+         manager.requestGroupInfo(channel, new WifiP2pManager.GroupInfoListener() {
+            @Override
+            public void onGroupInfoAvailable(WifiP2pGroup group) {
+                System.out.println(group);
+
+                if (group != null)
+                {
+                  groupPassword = group.getPassphrase();
+                  promise.resolve(groupPassword);
+                }
+                else {
+                    promise.resolve("NOT_AVAILABLE");
+                }   
+            }
+        });
+    }
+
     @ReactMethod
     public void init() {
         if (manager != null) { // prevent reinitialization

--- a/android/src/main/java/io/wifi/p2p/WiFiP2PManagerModule.java
+++ b/android/src/main/java/io/wifi/p2p/WiFiP2PManagerModule.java
@@ -35,7 +35,6 @@ public class WiFiP2PManagerModule extends ReactContextBaseJavaModule implements 
     private ReactApplicationContext reactContext;
     private final IntentFilter intentFilter = new IntentFilter();
     private WiFiP2PDeviceMapper mapper = new WiFiP2PDeviceMapper();
-    private String groupPassword;
 
     public WiFiP2PManagerModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -72,7 +71,7 @@ public class WiFiP2PManagerModule extends ReactContextBaseJavaModule implements 
             @Override
             public void onGroupInfoAvailable(WifiP2pGroup group) {
                 if (group != null) {
-                    groupPassword = group.getPassphrase();
+                    String groupPassword = group.getPassphrase();
                     promise.resolve(groupPassword);
                 }
                 else {

--- a/android/src/main/java/io/wifi/p2p/WiFiP2PManagerModule.java
+++ b/android/src/main/java/io/wifi/p2p/WiFiP2PManagerModule.java
@@ -10,6 +10,7 @@ import android.net.wifi.p2p.WifiP2pConfig;
 import android.net.wifi.p2p.WifiP2pDeviceList;
 import android.net.wifi.p2p.WifiP2pInfo;
 import android.net.wifi.p2p.WifiP2pManager;
+import android.net.wifi.p2p.WifiP2pGroup;
 import android.net.wifi.p2p.WifiP2pManager.PeerListListener;
 
 import com.facebook.react.bridge.Arguments;
@@ -34,6 +35,7 @@ public class WiFiP2PManagerModule extends ReactContextBaseJavaModule implements 
     private ReactApplicationContext reactContext;
     private final IntentFilter intentFilter = new IntentFilter();
     private WiFiP2PDeviceMapper mapper = new WiFiP2PDeviceMapper();
+    private String groupPassword;
 
     public WiFiP2PManagerModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -64,20 +66,17 @@ public class WiFiP2PManagerModule extends ReactContextBaseJavaModule implements 
         });
     }
 
-   @ReactMethod
+    @ReactMethod
     public void getGroupPassphraseInfo(final Promise promise) {
-         manager.requestGroupInfo(channel, new WifiP2pManager.GroupInfoListener() {
+        manager.requestGroupInfo(channel, new WifiP2pManager.GroupInfoListener() {
             @Override
             public void onGroupInfoAvailable(WifiP2pGroup group) {
-                System.out.println(group);
-
-                if (group != null)
-                {
-                  groupPassword = group.getPassphrase();
-                  promise.resolve(groupPassword);
+                if (group != null) {
+                    groupPassword = group.getPassphrase();
+                    promise.resolve(groupPassword);
                 }
                 else {
-                    promise.resolve("NOT_AVAILABLE");
+                    promise.resolve(null);
                 }   
             }
         });

--- a/index.js
+++ b/index.js
@@ -94,6 +94,8 @@ const receiveMessage = () => new Promise((resolve, reject) => {
 
 const getConnectionInfo = () => WiFiP2PManager.getConnectionInfo();
 
+const getGroupPassphraseInfo = () => WiFiP2PManager.getGroupPassphraseInfo();
+
 //////////////////////////////////////////////////////////////////
 
 const isWiFiEnabled = () => true;
@@ -116,7 +118,8 @@ export {
     createGroup,
     removeGroup,
     getConnectionInfo,
-
+    getGroupPassphraseInfo,
+    
     // experimental
     sendFile,
     receiveFile,


### PR DESCRIPTION
After `createGroup()` method is exectuted, we can call getGroupPassPhraseInfo() to get passphrase required to connect to WiFI Direct group. Only catch is, not able to chain just immediately after createGroup. Instead, we can wait for 3 seconds, get passPhrase
